### PR TITLE
FT / BUG : Add cli feature path env and fix build command with build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry settings
   ```
+  You can also set the `TSAR_SETTINGS_URL` environment variable to load a custom `settings.json` from another location.
 
 > The default registry is this open source repository. The whole community can contribute and share their agents!
 
@@ -121,6 +122,7 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry settings
   ```
+  Vous pouvez également définir la variable d'environnement `TSAR_SETTINGS_URL` pour charger un `settings.json` personnalisé depuis un autre emplacement.
 
 > Le registry par défaut est ce dépôt open source. Toute la communauté peut y contribuer pour partager ses agents !
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,6 +39,7 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry settings
   ```
+  You can also set the `TSAR_SETTINGS_URL` environment variable to load a custom `settings.json` from another location.
 
 > The default registry is this open source repository. The whole community can contribute and share their agents!
 
@@ -121,6 +122,7 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry settings
   ```
+  Vous pouvez également définir la variable d'environnement `TSAR_SETTINGS_URL` pour charger un `settings.json` personnalisé depuis un autre emplacement.
 
 > Le registry par défaut est ce dépôt open source. Toute la communauté peut y contribuer pour partager ses agents !
 

--- a/cli/build.ts
+++ b/cli/build.ts
@@ -8,8 +8,11 @@ import { write } from 'bun';
   const settings = await loadSettings();
   const ignoreExtensions: string[] = settings.build?.ignoreExtensions || [];
 
-  // Racine du dossier registry
-  const REGISTRY_ROOT = path.join(process.cwd(), 'app', 'src', 'mastra', 'registry');
+  // Racine du dossier registry (argument CLI ou valeur par défaut)
+  const registryArg = process.argv[2] || 'app/src/mastra/registry';
+  const REGISTRY_ROOT = path.isAbsolute(registryArg)
+    ? registryArg
+    : path.join(process.cwd(), registryArg);
   const OUTPUT_PATH = path.join(process.cwd(), 'registry.json');
 
   // Types supportés

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,16 +10,10 @@ yargs(hideBin(process.argv))
   .command(
     'settings',
     'Affiche les paramètres de configuration',
-    (yargs) => {
-      return yargs.option('settings-path', {
-        alias: 's',
-        describe: 'Chemin local ou URL du fichier settings.json',
-        type: 'string',
-      });
-    },
-    async (argv) => {
+    () => {},
+    async () => {
       try {
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         console.log(JSON.stringify(settings, null, 2));
       } catch (e: any) {
         console.error("Erreur lors du chargement des settings:", e.message);
@@ -35,15 +29,11 @@ yargs(hideBin(process.argv))
         describe: 'Type d\'objet à lister',
         choices: ['agents', 'workflows', 'tools', 'mcp'],
         type: 'string',
-      }).option('settings-path', {
-        alias: 's',
-        describe: 'Chemin local ou URL du fichier settings.json',
-        type: 'string',
       });
     },
     async (argv) => {
       try {
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         const registryPath = settings.settings?.registry;
         const settingsUrl = settings.settings?.url;
         if (!registryPath) throw new Error("Le chemin du registry n'est pas défini dans les settings.");
@@ -73,16 +63,12 @@ yargs(hideBin(process.argv))
       return yargs.positional('name', {
         describe: "Name of the object to add (e.g., research-agent)",
         type: 'string',
-      }).option('settings-path', {
-        alias: 's',
-        describe: 'Local path or URL to the settings.json file',
-        type: 'string',
       });
     },
     async (argv) => {
       try {
         const name = argv.name as string;
-        const settings = await loadSettings(argv["settings-path"] as string | undefined);
+        const settings = await loadSettings();
         const registryPath = settings.settings?.registry;
         const settingsUrl = settings.settings?.url;
         const localPath = settings.settings?.local;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -220,8 +220,12 @@ yargs(hideBin(process.argv))
     async (argv) => {
       try {
         const { spawn } = require('child_process');
-        const buildScript = path.join(__dirname, 'build.ts');
-        const proc = spawn('bun', [buildScript], { stdio: 'inherit', env: process.env });
+        const buildScript = path.join(__dirname, 'build.js');
+        const registryArg = argv.registryPath as string;
+        const proc = spawn('bun', [buildScript, registryArg], {
+          stdio: 'inherit',
+          env: process.env,
+        });
         proc.on('close', (code: number) => process.exit(code));
       } catch (e: any) {
         console.error('Erreur lors de la génération du registry:', e.message);

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,7 @@
     "settings.json"
   ],
   "scripts": {
-    "build": "bun build index.ts --outdir dist --target bun",
+    "build": "bun build index.ts build.ts --outdir dist --target bun",
     "prepublishOnly": "bun run build"
   },
   "repository": {

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -4,7 +4,8 @@ import path from 'path';
 export async function loadSettings(settingsPath?: string): Promise<any> {
   let data: string;
   if (!settingsPath) {
-    settingsPath = "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
+    settingsPath = process.env.TSAR_SETTINGS_URL ||
+      "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
   }
   if (settingsPath.startsWith("http://") || settingsPath.startsWith("https://")) {
     const res = await fetch(settingsPath);

--- a/docs/src/lib/docs-navigation.ts
+++ b/docs/src/lib/docs-navigation.ts
@@ -12,6 +12,7 @@ export interface NavigationItem {
 interface PageFrontmatter {
   title?: string
   description?: string
+  navbar_title?: string
   order?: number
   [key: string]: any
 }
@@ -76,8 +77,12 @@ export const getNavigationItems = (): NavigationItem[] => {
         if (value.__file) {
           // Si c'est la racine de /docs ou un index, on affiche "Introduction"
           const isRootIndex = value.path === '/docs' || value.path === '/docs/index';
+          const navTitle = value.frontmatter.navbar_title ||
+            (isRootIndex
+              ? 'Introduction'
+              : formatTitle(key === 'index' ? (parentPath.split('/').pop() || 'Index') : key));
           return {
-            title: isRootIndex ? 'Introduction' : formatTitle(key === 'index' ? (parentPath.split('/').pop() || 'Index') : key),
+            title: navTitle,
             url: value.path === '/docs/index' ? '/docs' : value.path,
             icon: getIcon(key),
             order: value.frontmatter.order ?? 9999,

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -1,0 +1,89 @@
+---
+layout: '@/layouts/docs-mdx.astro'
+title: "CLI"
+navbar_title: "CLI"
+order: 4
+description: "How to use the tsai-registry CLI"
+---
+
+# tsai-registry CLI
+
+This page describes the available commands of the `tsai-registry` CLI and how they rely on the `settings.json` file.
+
+## General usage
+
+Run commands with `npx`:
+
+```bash
+npx tsai-registry <command>
+```
+
+## Available commands
+
+### `settings`
+
+Display the configuration used by the CLI:
+
+```bash
+npx tsai-registry settings
+```
+
+The configuration is loaded with the `loadSettings` function from `cli/utils.ts`.
+
+### `list [type]`
+
+List objects from the registry. The optional `type` can be `agents`, `workflows`, `tools` or `mcp`.
+
+```bash
+npx tsai-registry list agents
+```
+
+The CLI reads the registry path from `settings.json`, loads `registry.json` and displays the matching entries.
+
+### `add <name>`
+
+Copy an agent, workflow or tool from the registry locally. The command downloads the files listed in `registry.json`, installs the required dependencies and prints environment variables to add.
+
+```bash
+npx tsai-registry add weather-agent
+```
+
+The destination folder is defined by `settings.local` in `settings.json`. If the folder already exists, the CLI asks whether to overwrite it.
+
+### `build [registryPath]`
+
+Generate a `registry.json` file from a local folder containing your agents. The default path is `app/src/mastra/registry`, but you can provide a custom one:
+
+```bash
+npx tsai-registry build ./my-agents
+```
+
+The command iterates through the `agents`, `workflows` and `tools` subfolders and gathers the files needed for each entry. It ignores extensions listed in `build.ignoreExtensions` from `settings.json`.
+
+## `settings.json`
+
+The `settings.json` file centralises the CLI configuration. Example:
+
+```json
+{
+  "settings": {
+    "url": "https://github.com/aidalinfo/tsai-registry",
+    "registry": "registry.json",
+    "local": "src/mastra/registry"
+  },
+  "build": {
+    "ignoreExtensions": [
+      ".md",
+      ".yaml"
+    ]
+  }
+}
+```
+
+- **settings.url**: URL of the default registry repository.
+- **settings.registry**: path to the `registry.json` file to load.
+- **settings.local**: folder where objects added with the `add` command are copied.
+- **build.ignoreExtensions**: file extensions ignored when generating the registry with `build`.
+
+You can set the `TSAR_SETTINGS_URL` environment variable to override the official settings URL. This lets you point the CLI to a different registry repository. If no flag or variable is provided, the CLI falls back to the default URL declared in `cli/utils.ts`.
+

--- a/docs/src/pages/docs/contribute.mdx
+++ b/docs/src/pages/docs/contribute.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Contribute"
+navbar_title: "Contrib"
 order: 3
 description: "Guide to contributing agents to the tsai-registry"
 ---

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Introduction"
+navbar_title: "Intro"
 order: 1
 description: "Complete guide to using tsai-registry - Collection of Mastra agents and tools"
 ---
@@ -8,6 +9,8 @@ description: "Complete guide to using tsai-registry - Collection of Mastra agent
 # tsai-registry
 
 Welcome to **tsai-registry**, an open-source library of pre-built agents, tools, and workflows for Mastra framework.
+
+> **Note**: You can customize the label displayed in the sidebar by setting `navbar_title` in the frontmatter of your page.
 
 ## 🎯 What is tsai-registry?
 

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Introduction"
-navbar_title: "Intro"
+navbar_title: "Introduction"
 order: 1
 description: "Complete guide to using tsai-registry - Collection of Mastra agents and tools"
 ---
@@ -9,8 +9,6 @@ description: "Complete guide to using tsai-registry - Collection of Mastra agent
 # tsai-registry
 
 Welcome to **tsai-registry**, an open-source library of pre-built agents, tools, and workflows for Mastra framework.
-
-> **Note**: You can customize the label displayed in the sidebar by setting `navbar_title` in the frontmatter of your page.
 
 ## 🎯 What is tsai-registry?
 

--- a/docs/src/pages/docs/installation.mdx
+++ b/docs/src/pages/docs/installation.mdx
@@ -1,6 +1,7 @@
 ---
 layout: '@/layouts/docs-mdx.astro'
 title: "Installation"
+navbar_title: "Install"
 order: 2
 description: "Installation guide for tsai-registry"
 ---


### PR DESCRIPTION
This pull request introduces several updates to enhance the functionality and usability of the `tsai-registry` CLI, improve documentation, and provide better configurability. Key changes include adding support for custom settings URLs, refining CLI commands, and updating documentation navigation and content.

### CLI Enhancements
* [`cli/utils.ts`](diffhunk://#diff-046f5c3bf299a5904ecec380d368d3f593686f5b5ec99d789418a089ca394db4L7-R8): Added support for the `TSAR_SETTINGS_URL` environment variable to override the default `settings.json` URL.
* [`cli/build.ts`](diffhunk://#diff-9a6512417dabe27c25bae20570e5a549326456e74e2491a4e5474133e2db4c99L11-R15): Updated the registry root path to accept a CLI argument or use a default value, improving flexibility.
* [`cli/index.ts`](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL13-R16): Simplified CLI commands by removing the `--settings-path` option and relying on `loadSettings` to handle configuration. Updated the `build` command to accept a `registryPath` argument. [[1]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL13-R16) [[2]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL38-R36) [[3]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL76-R71) [[4]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL223-R214)
* [`cli/package.json`](diffhunk://#diff-088b5e0ac52dd36816ebc6b121d5423c763c3c18c098b91757c014937c7d632dL16-R16): Updated the build script to include `build.ts` in the output directory.

### Documentation Updates
* [`docs/src/lib/docs-navigation.ts`](diffhunk://#diff-38e1e837c91983adaed5d494e4724630b7eb46e2529c72868ae1631dfd940e55R15): Added support for a `navbar_title` field in frontmatter to customize navigation titles. [[1]](diffhunk://#diff-38e1e837c91983adaed5d494e4724630b7eb46e2529c72868ae1631dfd940e55R15) [[2]](diffhunk://#diff-38e1e837c91983adaed5d494e4724630b7eb46e2529c72868ae1631dfd940e55R80-R85)
* [`docs/src/pages/docs/cli.md`](diffhunk://#diff-93f1f085738176ce68970ffeae417eef74bf04d9fc94e7df07f7ca5b059270fcR1-R89): Added a new page documenting the CLI commands, including usage examples and configuration details.
* Updated frontmatter in documentation pages to include `navbar_title` for better navigation labels:
  - [`docs/src/pages/docs/index.mdx`](diffhunk://#diff-d257e59fb0044ee1c82adfc6eeafb2054095eaa05670d6d07b97b80fadcf9db6R4): Added "Introduction" as the navigation title.
  - [`docs/src/pages/docs/installation.mdx`](diffhunk://#diff-ec3114b7f611ae1d29ea248051c6da726319efa9c9b28b424b6390a67a5b9332R4): Added "Install" as the navigation title.
  - [`docs/src/pages/docs/contribute.mdx`](diffhunk://#diff-2c8bb2a656bc92d11f6eba5f673e6b5ffc5c10d215bcf7c619c602dffbcf805fR4): Added "Contrib" as the navigation title.

### README Improvements
* `README.md` and `cli/README.md`: Added instructions for using the `TSAR_SETTINGS_URL` environment variable to load a custom `settings.json`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125) [[3]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabR42) [[4]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabR125)