### PR TITLE
New feature, local JSON registry

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -72,6 +72,26 @@ async function handleEnvVariables(envs: string[] | undefined) {
 
 yargs(hideBin(process.argv))
   .command(
+    'init',
+    'Create a local settings-registry.json file',
+    () => {},
+    async () => {
+      const defaultPath = 'src/mastra/registry';
+      const input = await prompt(`Local registry path [${defaultPath}]: `);
+      const localPath = input.trim() || defaultPath;
+      const filePath = path.join(process.cwd(), 'settings-registry.json');
+      if (fs.existsSync(filePath)) {
+        const overwrite = (await prompt('settings-registry.json already exists. Overwrite? (y/N): ')).trim().toLowerCase();
+        if (overwrite !== 'y') {
+          console.log('Aborted.');
+          return;
+        }
+      }
+      fs.writeFileSync(filePath, JSON.stringify({ settings: { local: localPath } }, null, 2));
+      console.log(`settings-registry.json written to ${filePath}`);
+    }
+  )
+  .command(
     'settings',
     'Affiche les paramètres de configuration',
     () => {},

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -3,11 +3,18 @@ import path from 'path';
 
 export async function loadSettings(settingsPath?: string): Promise<any> {
   let data: string;
+  let overrideLocalPath: string | undefined;
+
   if (!settingsPath) {
+    const localOverride = path.join(process.cwd(), 'settings-registry.json');
+    if (fs.existsSync(localOverride)) {
+      overrideLocalPath = JSON.parse(fs.readFileSync(localOverride, 'utf-8')).settings?.local;
+    }
     settingsPath = process.env.TSAR_SETTINGS_URL ||
       "https://raw.githubusercontent.com/aidalinfo/tsai-registry/refs/heads/main/settings.json";
   }
-  if (settingsPath.startsWith("http://") || settingsPath.startsWith("https://")) {
+
+  if (settingsPath.startsWith('http://') || settingsPath.startsWith('https://')) {
     const res = await fetch(settingsPath);
     if (!res.ok) throw new Error(`Erreur lors du chargement distant: ${res.statusText}`);
     data = await res.text();
@@ -16,9 +23,15 @@ export async function loadSettings(settingsPath?: string): Promise<any> {
       ? settingsPath
       : path.join(process.cwd(), settingsPath);
     if (!fs.existsSync(resolvedPath)) throw new Error(`Fichier introuvable: ${resolvedPath}`);
-    data = fs.readFileSync(resolvedPath, "utf-8");
+    data = fs.readFileSync(resolvedPath, 'utf-8');
   }
-  return JSON.parse(data);
+
+  const base = JSON.parse(data);
+  if (overrideLocalPath) {
+    base.settings = base.settings || {};
+    base.settings.local = overrideLocalPath;
+  }
+  return base;
 }
 
 export async function loadRegistry(registryPath: string, settingsUrl?: string): Promise<any> {


### PR DESCRIPTION
This pull request introduces a new `init` command to the CLI for creating a local `settings-registry.json` file and enhances the `loadSettings` function to support overriding the local settings path. These changes improve user configurability and provide a fallback mechanism for loading settings.

### New CLI Command:
* Added an `init` command to the CLI to create a `settings-registry.json` file with a customizable local registry path. The command handles user prompts for input and confirms overwriting if the file already exists. (`cli/index.ts`, [cli/index.tsR74-R93](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebR74-R93))

### Enhancements to `loadSettings`:
* Modified the `loadSettings` function to check for a local `settings-registry.json` file and use its `local` path as an override if available. (`cli/utils.ts`, [cli/utils.tsR6-R17](diffhunk://#diff-046f5c3bf299a5904ecec380d368d3f593686f5b5ec99d789418a089ca394db4R6-R17))
* Added logic to `loadSettings` to fetch and merge a fallback `local` path from remote or default settings if not defined locally. This ensures robust handling of missing configurations. (`cli/utils.ts`, [cli/utils.tsL19-R63](diffhunk://#diff-046f5c3bf299a5904ecec380d368d3f593686f5b5ec99d789418a089ca394db4L19-R63))