### PR TITLE
Update CLI DOCS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry add <agent-name>
   ```
+- **Initialise local configuration:**
+  ```sh
+  npx tsai-registry init
+  ```
+  Creates a `settings-registry.json` file asking for the local registry path (default `src/mastra/registry`). The command also confirms if the file already exists.
 - **Show the current configuration:**
   ```sh
   npx tsai-registry settings
@@ -119,6 +124,11 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry add <nom-agent>
   ```
+- **Initialiser la configuration locale :**
+  ```sh
+  npx tsai-registry init
+  ```
+  Génère un fichier `settings-registry.json` en demandant le chemin du dossier local (par défaut `src/mastra/registry`) et confirme l'écrasement s'il existe déjà.
 - **Afficher la configuration utilisée :**
   ```sh
   npx tsai-registry settings

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,6 +35,11 @@ The AI ecosystem is moving fast, and many Python frameworks (LangChain, CrewAI, 
   ```sh
   npx tsai-registry add <agent-name>
   ```
+- **Initialise local configuration:**
+  ```sh
+  npx tsai-registry init
+  ```
+  Creates a `settings-registry.json` file asking for the local registry path (default `src/mastra/registry`). The command also confirms if the file already exists.
 - **Show the current configuration:**
   ```sh
   npx tsai-registry settings
@@ -118,6 +123,11 @@ L'écosystème de l'IA évolue rapidement, et de nombreux frameworks Python (Lan
   ```sh
   npx tsai-registry add <nom-agent>
   ```
+- **Initialiser la configuration locale :**
+  ```sh
+  npx tsai-registry init
+  ```
+  Génère un fichier `settings-registry.json` en demandant le chemin du dossier local (par défaut `src/mastra/registry`) et confirme l'écrasement s'il existe déjà.
 - **Afficher la configuration utilisée :**
   ```sh
   npx tsai-registry settings

--- a/docs/src/pages/docs/cli.mdx
+++ b/docs/src/pages/docs/cli.mdx
@@ -20,6 +20,17 @@ npx tsai-registry <command>
 
 ## Available commands
 
+### `init`
+
+Create a local `settings-registry.json` file. This file overrides
+`settings.local` from `settings.json` and indicates where downloaded components
+should be stored. The command asks for the local registry path (default
+`src/mastra/registry`) and, if the file already exists, whether to overwrite it.
+
+```bash
+npx tsai-registry init
+```
+
 ### `settings`
 
 Display the configuration used by the CLI:

--- a/docs/src/pages/docs/contribute.mdx
+++ b/docs/src/pages/docs/contribute.mdx
@@ -125,6 +125,7 @@ Once your PR is approved and merged:
 1. The maintainers will update the registry configuration using the CLI
 2. Your agent will be built and added to the CLI registry
 3. Users can then install it with `npx tsai-registry add your-agent-name`
+   after running `npx tsai-registry init` to set their local registry folder.
 
 ## Best Practices
 

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -55,6 +55,16 @@ At this stage, we have 3 working agents available, but this is just the beginnin
 
 ## 🔧 How it works
 
+### Initialize the CLI
+Run `npx tsai-registry init` once in your project. The command creates a
+`settings-registry.json` file storing the local folder where components will be
+copied. It asks for this path (default `src/mastra/registry`) and confirms if an
+existing file should be overwritten.
+
+```bash
+npx tsai-registry init
+```
+
 ### 1. Browse & Discover
 Explore the registry to find components that match your needs:
 

--- a/docs/src/pages/docs/installation.mdx
+++ b/docs/src/pages/docs/installation.mdx
@@ -22,6 +22,13 @@ Before installing tsai-registry, make sure you have:
 
 The easiest way to get started is using the tsai-registry CLI tool. **Make sure you are in the root directory of your project** before running these commands.
 
+### Initialize configuration
+Create a `settings-registry.json` file to define where components will be stored locally. The `init` command asks for the folder path (default `src/mastra/registry`) and whether to overwrite the file if it already exists.
+
+```bash
+npx tsai-registry init
+```
+
 ### List available components
 
 ```bash


### PR DESCRIPTION
This pull request introduces a new `init` command to the `tsai-registry` CLI, which allows users to create and configure a `settings-registry.json` file for specifying the local registry path. The changes include updates to documentation files and examples to incorporate this new command.

### Documentation Updates for the `init` Command:

* **README Files**:
  - Added instructions for the `init` command to both the English and French sections of `README.md` and `cli/README.md`. The command creates a `settings-registry.json` file, prompts for the local registry path (default `src/mastra/registry`), and confirms overwriting if the file exists. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R131) [[3]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabR38-R42) [[4]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabR126-R130)

* **Command Reference**:
  - Included a detailed description of the `init` command in `docs/src/pages/docs/cli.mdx`, explaining its purpose, behavior, and usage example.

* **Installation and Usage Guides**:
  - Updated `docs/src/pages/docs/installation.mdx` to highlight the need to run the `init` command when setting up the CLI, specifying its role in creating the configuration file.
  - Added a new section in `docs/src/pages/docs/index.mdx` about initializing the CLI with the `init` command, describing its functionality and providing an example.

* **Contribution Workflow**:
  - Modified `docs/src/pages/docs/contribute.mdx` to include a step for running the `init` command before using the CLI to add agents to the registry.